### PR TITLE
Add Azure.Compute.VirtualMachine_RequireAvailabilitySet

### DIFF
--- a/Azure.Compute.VirtualMachine_RequireAvailabilitySet.rego
+++ b/Azure.Compute.VirtualMachine_RequireAvailabilitySet.rego
@@ -1,0 +1,3 @@
+allow {
+  startswith(input.availability_set_id, "/")
+}


### PR DESCRIPTION
This rule checks whether Azure Virtual Machines have been deployed in availability sets.