### PR TITLE
Add rule to require specific tags for AWS taggable resources

### DIFF
--- a/AWS.TaggedResource_RequireTags.rego
+++ b/AWS.TaggedResource_RequireTags.rego
@@ -1,0 +1,5 @@
+# For AWS resources that support tags, require a tag named Stage with a value Prod
+
+allow {
+  input.tags.Stage == "Prod"
+}


### PR DESCRIPTION
This custom rule requires a tag named `Stage` with a value `Prod` for AWS resources that support tagging.