### PR TITLE
Add 3 simple rules, 1 advanced rule

### DIFF
--- a/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
+++ b/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
@@ -1,0 +1,63 @@
+# The following multi-resource type validation checks ALL supported taggable AWS resources for a tag named Stage with a value Prod.
+
+taggable_resource_types = {
+  "AWS.CloudFront.Distribution",
+  "AWS.CloudWatch.MetricAlarm",
+  "AWS.CloudWatchEvents.Rule",
+  "AWS.CloudWatchLogs.LogGroup",
+  "AWS.Cognito.UserPool",
+  "AWS.Config.Rule",
+  "AWS.DynamoDB.Table",
+  "AWS.EC2.CustomerGateway",
+  "AWS.EC2.DhcpOptions",
+  "AWS.EC2.ElasticIP",
+  "AWS.EC2.Instance",
+  "AWS.EC2.InternetGateway",
+  "AWS.EC2.NetworkACL",
+  "AWS.EC2.NetworkInterface",
+  "AWS.EC2.RouteTable",
+  "AWS.EC2.SecurityGroup",
+  "AWS.EC2.Subnet",
+  "AWS.EC2.Volume",
+  "AWS.EC2.Vpc",
+  "AWS.EC2.VpnConnection",
+  "AWS.EC2.VpnGateway",
+  "AWS.ELB.LoadBalancer",
+  "AWS.ELBv2.LoadBalancer",
+  "AWS.ELBv2.TargetGroup",
+  "AWS.ElastiCache.Cluster",
+  "AWS.KMS.Key",
+  "AWS.Lambda.Function",
+  "AWS.Redshift.Cluster",
+  "AWS.Redshift.ParameterGroup",
+  "AWS.Redshift.SubnetGroup",
+  "AWS.RDS.Instance",
+  "AWS.RDS.ParameterGroup",
+  "AWS.RDS.SubnetGroup",
+  "AWS.RDS.EventSubscription",
+  "AWS.RDS.OptionGroup",
+  "AWS.Route53.HealthCheck",
+  "AWS.Route53.Zone",
+  "AWS.S3.Bucket",
+  "AWS.SFN.StateMachine"
+}
+
+taggable_resources[id] = resource {
+  taggable_resource_types[resource_type]
+  resources = fugue.resources(resource_type)
+  resource = resources[id]
+}
+
+is_properly_tagged(resource) {
+  resource.tags.Stage == "Prod"
+}
+
+policy[r] {
+   resource = taggable_resources[_]
+   is_properly_tagged(resource)
+   r = fugue.allow_resource(resource)
+} {
+   resource = taggable_resources[_]
+   not is_properly_tagged(resource)
+   r = fugue.deny_resource(resource)
+}

--- a/simple/AWS.EC2.Instance_ApprovedAMI.rego
+++ b/simple/AWS.EC2.Instance_ApprovedAMI.rego
@@ -1,0 +1,11 @@
+# AWS.EC2.Instance
+# All EC2 instances must use an approved AMI. Replace the AMI ID below with your AMI ID.
+
+approved_ami = {
+  'ami-04b762b4289fba92b'
+}
+
+allow {
+    ami = input.ami  # Pull out AMIs
+    approved_ami[ami]  # Assert 
+}

--- a/simple/AWS.EC2.Instance_ApprovedAMI.rego
+++ b/simple/AWS.EC2.Instance_ApprovedAMI.rego
@@ -1,11 +1,11 @@
 # AWS.EC2.Instance
 # All EC2 instances must use an approved AMI. Replace the AMI ID below with your AMI ID.
 
-approved_ami = {
+approved_amis = {
   'ami-04b762b4289fba92b'
 }
 
 allow {
     ami = input.ami  # Pull out AMIs
-    approved_ami[ami]  # Assert 
+    approved_amis[ami]  # Assert
 }

--- a/simple/AWS.S3.Bucket_SSE_Enabled.rego
+++ b/simple/AWS.S3.Bucket_SSE_Enabled.rego
@@ -1,0 +1,7 @@
+# AWS.S3.Bucket
+# SSE encryption should be enabled for S3 buckets (AES-256 or KMS).
+
+allow{
+      input.server_side_encryption_configuration[_].rule[_][_][_].sse_algorithm
+= _
+    }

--- a/simple/AWS.S3.Bucket_SSE_Enabled.rego
+++ b/simple/AWS.S3.Bucket_SSE_Enabled.rego
@@ -1,7 +1,6 @@
 # AWS.S3.Bucket
 # SSE encryption should be enabled for S3 buckets (AES-256 or KMS).
 
-allow{
-      input.server_side_encryption_configuration[_].rule[_][_][_].sse_algorithm
-= _
-    }
+allow {
+  input.server_side_encryption_configuration[_].rule[_][_][_].sse_algorithm = _
+}

--- a/simple/Azure.SQL.FirewallRule_Deny_Azure_services_from_accessing_server.rego
+++ b/simple/Azure.SQL.FirewallRule_Deny_Azure_services_from_accessing_server.rego
@@ -1,0 +1,7 @@
+# SQL Server firewall rules should not permit start and end IP addresses to be 0.0.0.0
+# Setting start and end IP address to 0.0.0.0 for a SQL firewall rule allows any Azure-internal IP address to access the SQL server. Removing unfettered connectivity to a SQL server reduces the chance of exposing critical data.
+
+deny {
+  input.start_ip_address == "0.0.0.0"
+  input.end_ip_address == "0.0.0.0"
+}


### PR DESCRIPTION
This PR adds the following *simple* rules:

- AWS EC2 instances must use an approved AMI
- SSE encryption should be enabled for AWS S3 buckets (AES-256 or KMS)
- Azure SQL Server firewall rules should not permit start and end IP addresses to be 0.0.0.0

This PR adds the following *advanced* rule:

- ALL supported taggable AWS resources should have a tag named Stage with a value Prod