### PR TITLE
Add note to AllTaggableResourcesRequireTags.rego about commenting out unused resource types

### DIFF
--- a/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
+++ b/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
@@ -1,4 +1,6 @@
-# The following multi-resource type validation checks ALL supported taggable AWS resources for a tag named Stage with a value Prod.
+# The following multi-resource type validation checks ALL supported taggable
+# AWS resources for a tag named Stage with a value Prod. Comment out the
+# resources you don't use in any environment.
 
 taggable_resource_types = {
   "AWS.CloudFront.Distribution",


### PR DESCRIPTION
This PR adds a clarification to the comments in `Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego` so users know they can comment out the resources they don't use in any environment.