### PR TITLE
Advanced rule - Azure managed disks with Linux must have 'application' tag

### DIFF
--- a/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
+++ b/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
@@ -5,6 +5,9 @@
 # Linux have an "application" tag with a non-blank value. Because this is 
 # an advanced custom rule, select "MULTIPLE" from the Resource Type 
 # dropdown on the Fugue Custom Rules page.
+#
+# This is an advanced rule because it validates Linux managed disks only;
+# it can be written as a simple rule if you want to validate all managed disks.
 
 # All managed disks in the env
 managed_disks = fugue.resources("Azure.Compute.ManagedDisk")

--- a/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
+++ b/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
@@ -1,0 +1,28 @@
+# Resource type: MULTIPLE
+# Name: Azure managed disks running Linux must have "application" tag
+#
+# The following advanced custom rule checks that all managed disks running 
+# Linux have an "application" tag with a non-blank value. Because this is 
+# an advanced custom rule, select "MULTIPLE" from the Resource Type 
+# dropdown on the Fugue Custom Rules page.
+
+# All managed disks in the env
+managed_disks = fugue.resources("Azure.Compute.ManagedDisk")
+
+# Valid disks have the tag key "application" and a value that isn't an empty string
+valid(disk) {
+  disk.tags.application != ""
+}
+
+# Each managed disk running Linux passes if it has an application tag and fails if it does not
+policy[r] {
+   managed_disk = managed_disks[_]
+   managed_disk.os_type == "Linux"
+   valid(managed_disk) 
+   r = fugue.allow_resource(managed_disk)
+} {
+   managed_disk = managed_disks[_]
+   managed_disk.os_type == "Linux"
+   not valid(managed_disk) 
+   r = fugue.deny_resource(managed_disk)
+}


### PR DESCRIPTION
This rule checks only Azure managed disks with OS type Linux and fails disks that don't have an `application` tag key. Linux disks that have an `application` tag pass.

The validation is not applied to Windows or data disks.