### PR TITLE
Use fugue.resource_types() in tag rule

### DIFF
--- a/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
+++ b/advanced/Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego
@@ -150,10 +150,12 @@ taggable_resource_types = {
   "aws_workspaces_workspace"
 }
 
+scanned_resource_types := fugue.resource_types()
+
 # For each taggable resource type, add each of its resources 
 # to the taggable_resources collection
 taggable_resources[id] = resource {
-  some type_name
+  scanned_resource_types[type_name]
   taggable_resource_types[type_name]
   resources = fugue.resources(type_name)
   resource = resources[id]


### PR DESCRIPTION
This PR changes our "require tags" example rule to use the `fugue.resource_types()` function. The current implementation results in missing resource type errors for every type that's not in the scan. After this change, the rule is only evaluated for resource types that are in the scan.

More info on `fugue.resource_types()`: https://docs.fugue.co/rules-advanced.html#advanced-rule-functions