### PR TITLE
Rules updates

### DIFF
--- a/advanced/Advanced_AWS.EC2.SecurityGroup_NoIngressPort9200.rego
+++ b/advanced/Advanced_AWS.EC2.SecurityGroup_NoIngressPort9200.rego
@@ -3,6 +3,7 @@
 # custom-rules/simple/AWS.EC2.SecurityGroup_NoIngressPort9200.rego.
 
 package rules.sg_9200
+import data.fugue
 
 __rego__metadoc__ := {
   "title": "Advanced-AWS.EC2.SecurityGroup-NoIngressPort9200",

--- a/advanced/Advanced_AWS.MultiResource_VPC_SGs_RequireTags.rego
+++ b/advanced/Advanced_AWS.MultiResource_VPC_SGs_RequireTags.rego
@@ -1,4 +1,5 @@
 package rules.vpc_sgs_tags
+import data.fugue
 
 __rego__metadoc__ := {
   "title": "Advanced-AWS.MultiResource-VPC-SGs-RequireTags",

--- a/advanced/Advanced_AWS_GOVCLOUD.EC2.SecurityGroup_Tagged_NoIngressPort9200.rego
+++ b/advanced/Advanced_AWS_GOVCLOUD.EC2.SecurityGroup_Tagged_NoIngressPort9200.rego
@@ -1,4 +1,5 @@
 package rules.sg_tagged_9200
+import data.fugue
 
 __rego__metadoc__ := {
   "title": "Advanced-AWS-GOVCLOUD.EC2.SecurityGroup-Tagged-NoIngressPort9200",

--- a/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
+++ b/advanced/Advanced_Azure.Compute.ManagedDisk_LinuxRequireTags.rego
@@ -1,4 +1,5 @@
 package rules.managed_disks_linux_tags
+import data.fugue
 
 __rego__metadoc__ := {
   "title": "Advanced-Azure.Compute.ManagedDisk-LinuxRequireTags",

--- a/advanced/Advanced_MultiCloud.MultiResource_AllTaggableResourcesRequireTags.rego
+++ b/advanced/Advanced_MultiCloud.MultiResource_AllTaggableResourcesRequireTags.rego
@@ -1,0 +1,58 @@
+package rules.all_taggable_resources_multicloud
+import data.fugue
+
+__rego__metadoc__ := {
+  "title": "All storage must be tagged environment:staging",
+  "description": "AWS, Azure, and Google storage resources should be tagged with environment:staging in both runtime and IaC",
+  "custom": {
+    "providers": ["AWS", "AZURE", "GOOGLE", "REPOSITORY"],
+    "severity": "Medium"
+  }
+}
+
+input_type = "tf"
+
+resource_type = "MULTIPLE"
+
+# The following multi-resource type validation checks AWS S3 buckets,
+# Azure storage accounts, and Google storage buckets (in runtime AND
+# infrastructure as code) for a tag named "environment" with the value
+# "staging"
+
+taggable_resource_types = {
+  "aws_s3_bucket",
+  "azurerm_storage_account",
+  "google_storage_bucket"
+}
+
+scanned_resource_types = fugue.input_resource_types
+
+# For each taggable resource type, add each of its resources 
+# to the taggable_resources collection
+taggable_resources[id] = resource {
+  some type_name
+  type_name = scanned_resource_types[_]
+  taggable_resource_types[type_name]
+  resources = fugue.resources(type_name)
+  resource = resources[id]
+}
+
+# Check if resource is properly tagged (AWS, Azure) or labeled
+# (Google) with environment:staging
+is_properly_tagged(resource) {
+  resource.tags.environment == "staging"
+} {
+  resource.labels.environment == "staging"
+}
+
+# If the resource is properly tagged, return a PASS rule result;
+# otherwise, a FAIL rule result
+policy[r] {
+   resource = taggable_resources[_]
+   is_properly_tagged(resource)
+   r = fugue.allow_resource(resource)
+} {
+   resource = taggable_resources[_]
+   not is_properly_tagged(resource)
+   r = fugue.deny_resource(resource)
+}


### PR DESCRIPTION
In this PR:

- New: `Advanced_MultiCloud.MultiResource_AllTaggableResourcesRequireTags.rego` checks to see if storage is tagged in AWS, Azure, and Google runtime environments as well as repository environments
- Updated: `Advanced_AWS.MultiResource_AllTaggableResourcesRequireTags.rego` now supports AWS auto-scaling groups that have a `tag` property instead of `tags`
- Updated: Added an `import data.fugue` line to some rules that were missing it, in case users want to adapt the rules to work with repository environments