### PR TITLE
Update fugue.rego lib

### DIFF
--- a/lib/fugue.rego
+++ b/lib/fugue.rego
@@ -1,5 +1,13 @@
 package fugue
 
+# Library
+
+# Deprecated: please use `input_resource_types`
+resource_types_v0 = resource_types
+
+input_resource_types = resource_types
+
+# Internal: please use `input_resource_types`
 resource_types = {rt |
   r = input.resources[_]
   rt = r._type
@@ -13,6 +21,11 @@ resources_by_type = {rt: rs |
   }
 }
 
+resource_providers = {provider |
+  r = input.resources[_]
+  provider = r._provider
+}
+
 resources(rt) = ret {
   ret = resources_by_type[rt]
 } {
@@ -23,36 +36,61 @@ resources(rt) = ret {
 }
 
 allow_resource(resource) = ret {
-  ret = {
+  ret := allow({"resource": resource})
+}
+
+allow(params) = ret {
+  ret := {
     "valid": true,
-    "id": resource.id,
-    "message": "",
-    "type": resource._type
+    "id": params.resource.id,
+    "type": params.resource._type,
+    "message": object.get(params, "message", ""),
   }
 }
 
 deny_resource(resource) = ret {
-  ret = deny_resource_with_message(resource, "invalid")
+  ret = deny({"resource": resource})
 }
 
 deny_resource_with_message(resource, message) = ret {
-  ret = {
+  ret := deny({"resource": resource, "message": message})
+}
+
+deny(params) = ret {
+  ret := {
     "valid": false,
-    "id": resource.id,
-    "message": message,
-    "type": resource._type
+    "id": params.resource.id,
+    "type": params.resource._type,
+    "message": object.get(params, "message", ""),
+    "attribute": object.get(params, "attribute", null),
   }
 }
 
 missing_resource(resource_type) = ret {
-  ret = missing_resource_with_message(resource_type, "invalid")
+  ret := missing({"resource_type": resource_type})
 }
 
 missing_resource_with_message(resource_type, message) = ret {
-  ret = {
+  ret := missing({"resource_type": resource_type, "message": message})
+}
+
+missing(params) = ret {
+  ret := {
     "valid": false,
     "id": "",
-    "message": message,
-    "type": resource_type
+    "type": params.resource_type,
+    "message": object.get(params, "message", "invalid"),
   }
 }
+
+report_v0(message, policy) = ret {
+  ok := all([p.valid | policy[p]])
+  msg := {true: "", false: message}
+  ret := {
+    "valid": ok,
+    "message": msg[ok],
+    "resources": policy,
+  }
+}
+
+input_type = "tf_runtime"


### PR DESCRIPTION
This PR updates the `fugue.rego` library to the latest version. This includes `input_resource_types` now.